### PR TITLE
Fix import error

### DIFF
--- a/src/cookie.js
+++ b/src/cookie.js
@@ -83,10 +83,11 @@ if (typeof process !== 'undefined' &&
   global.document = {
     cookie: ''
   }
-  module.exports = {
-    document: document,
-    setCookie: setCookie,
-    getCookie: getCookie,
-    deleteCookie: deleteCookie,
-  }
+}
+
+module.exports = {
+  document: document,
+  setCookie: setCookie,
+  getCookie: getCookie,
+  deleteCookie: deleteCookie,
 }


### PR DESCRIPTION
module.exports was in an if block that would not be executed during normal use of the library, resulting in an error when importing